### PR TITLE
Replace code memory size numeric literals with CONST

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ use kvm_bindings::kvm_userspace_memory_region;
 use kvm_ioctls::{Kvm, VcpuExit};
 use mmarinus::{perms, Kind, Map};
 
+const MEM_SIZE: usize = 0x2000;
+const CODE_SIZE: usize = 0x1000;
+
 #[naked]
 pub unsafe extern "sysv64" fn code() -> ! {
     asm!(
@@ -13,14 +16,15 @@ pub unsafe extern "sysv64" fn code() -> ! {
 code_start:
     hlt
 code_end:
-.fill((4096 - (code_end - code_start)))
+.fill(({CODE_SIZE} - (code_end - code_start)))
     ",
-        options(noreturn)
+    CODE_SIZE = const CODE_SIZE,
+    options(noreturn)
     )
 }
 
 fn main() {
-    const MEM_SIZE: usize = 0x1000;
+    assert!(MEM_SIZE >= CODE_SIZE);
 
     let kvm = Kvm::new().unwrap();
     let vm = kvm.create_vm().unwrap();
@@ -31,10 +35,8 @@ fn main() {
         .known::<perms::ReadWrite>(Kind::Private)
         .unwrap();
 
-    let code = unsafe { std::slice::from_raw_parts(code as *const u8, 4096) };
-    let target = unsafe { std::slice::from_raw_parts_mut(address_space.as_mut_ptr(), 4096) };
-
-    target.copy_from_slice(code);
+    let code = unsafe { std::slice::from_raw_parts(code as *const u8, CODE_SIZE) };
+    address_space[..CODE_SIZE].copy_from_slice(code);
 
     let mem_region = kvm_userspace_memory_region {
         slot: 0,


### PR DESCRIPTION
 - Expand code memory from 1K to 8K
 - Ensure that code size is less than allocated code memory
 - Remove unnecessary 'target' variable